### PR TITLE
add lequal_base method to be more extensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ There is a [Lua port here.](https://github.com/codeplea/minctest-lua)
 That produces the following output:
 
             test1         pass: 1   fail: 0      0ms
-            test2         pass: 2   fail: 0      1ms
-    ALL TESTS PASSED (3/3)
+            test2         pass: 3   fail: 0      1ms
+    ALL TESTS PASSED (4/4)
 
 
 

--- a/example.c
+++ b/example.c
@@ -9,6 +9,7 @@ void test1() {
 void test2() {
     lequal(5, 5);
     lfequal(5.5, 5.5);
+    lsequal("abc", "abc");
 }
 
 int main(int argc, char *argv[])
@@ -18,4 +19,3 @@ int main(int argc, char *argv[])
     lresults();
     return lfails != 0;
 }
-

--- a/minctest.h
+++ b/minctest.h
@@ -62,6 +62,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <time.h>
+#include <string.h>
 
 
 /* How far apart can floats be before we consider them unequal. */
@@ -126,6 +127,11 @@ static int lfails = 0;
 #define lfequal(a, b)\
     lequal_base(fabs((double)(a)-(double)(b)) <= LTEST_FLOAT_TOLERANCE\
      && fabs((double)(a)-(double)(b)) == fabs((double)(a)-(double)(b)), (double)(a), (double)(b), "%f")
+
+
+/* Assert two strings are equal. */
+#define lsequal(a, b)\
+    lequal_base(strcmp(a, b) == 0, a, b, "%s")
 
 
 #endif /*__MINCTEST_H__*/

--- a/minctest.h
+++ b/minctest.h
@@ -108,23 +108,24 @@ static int lfails = 0;
     }} while (0)
 
 
-/* Assert two integers are equal. */
-#define lequal(a, b) do {\
+/* Prototype to assert equal. */
+#define lequal_base(equality, a, b, format) do {\
     ++ltests;\
-    if ((a) != (b)) {\
+    if (!(equality)) {\
         ++lfails;\
-        printf("%s:%d (%d != %d)\n", __FILE__, __LINE__, (a), (b));\
+        printf("%s:%d ("format " != " format")\n", __FILE__, __LINE__, (a), (b));\
     }} while (0)
+
+
+/* Assert two integers are equal. */
+#define lequal(a, b)\
+    lequal_base((a) == (b), a, b, "%d")
 
 
 /* Assert two floats are equal (Within LTEST_FLOAT_TOLERANCE). */
-#define lfequal(a, b) do {\
-    ++ltests;\
-    const double __LF_COMPARE = fabs((double)(a)-(double)(b));\
-    if (__LF_COMPARE > LTEST_FLOAT_TOLERANCE || (__LF_COMPARE != __LF_COMPARE)) {\
-        ++lfails;\
-        printf("%s:%d (%f != %f)\n", __FILE__, __LINE__, (double)(a), (double)(b));\
-    }} while (0)
+#define lfequal(a, b)\
+    lequal_base(fabs((double)(a)-(double)(b)) <= LTEST_FLOAT_TOLERANCE\
+     && fabs((double)(a)-(double)(b)) == fabs((double)(a)-(double)(b)), (double)(a), (double)(b), "%f")
 
 
 #endif /*__MINCTEST_H__*/


### PR DESCRIPTION
`lequal_base` method is added, which ought to update `ltests`,`lfails` and print out failure messages.
Also add  `lsequal` method to compare strings. 