### PR TITLE
Change output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ There is a [Node.js port here](https://github.com/codeplea/minctest-node) and a 
 
 That produces the following output:
 
-            test1         pass: 1   fail: 0      0ms
-            test2         pass: 3   fail: 0      1ms
+            test1:
+             -- pass: 1                    fail: 0                    time: 12ms
+            test2:
+             -- pass: 3                    fail: 0                    time: 0ms
     ALL TESTS PASSED (4/4)
 
 

--- a/minctest.h
+++ b/minctest.h
@@ -73,30 +73,30 @@
 
 /* Track the number of passes, fails. */
 /* NB this is made for all tests to be in one file. */
-static int ltests = 0;
-static int lfails = 0;
+static size_t ltests = 0;
+static size_t lfails = 0;
 
 
 /* Display the test results. */
 #define lresults() do {\
     if (lfails == 0) {\
-        printf("ALL TESTS PASSED (%d/%d)\n", ltests, ltests);\
+        printf("ALL TESTS PASSED (%zu/%zu)\n", ltests, ltests);\
     } else {\
-        printf("SOME TESTS FAILED (%d/%d)\n", ltests-lfails, ltests);\
+        printf("SOME TESTS FAILED (%zu/%zu)\n", ltests-lfails, ltests);\
     }\
 } while (0)
 
 
 /* Run a test. Name can be any string to print out, test is the function name to call. */
 #define lrun(name, test) do {\
-    const int ts = ltests;\
-    const int fs = lfails;\
+    const size_t ts = ltests;\
+    const size_t fs = lfails;\
     const clock_t start = clock();\
-    printf("\t%-14s", name);\
+    printf("\t%s:\n", name);\
     test();\
-    printf("pass:%2d   fail:%2d   %4dms\n",\
+    printf("\t -- pass: %-20zu fail: %-20zu time: %ldms\n",\
             (ltests-ts)-(lfails-fs), lfails-fs,\
-            (int)((clock() - start) * 1000 / CLOCKS_PER_SEC));\
+            (long)((clock() - start) * 1000 / CLOCKS_PER_SEC));\
 } while (0)
 
 


### PR DESCRIPTION
For issue #2, I changed output format.

New format output example:
```
        Basic equalitypass:
         -- pass: 4092                 fail: 0                    time: 0ms
        Indexing:
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
c:\users\mothe\documents\github\the-theory-of-automata-and-formal-languages-5-semester\minctest\example.c:18 (a != b)
         -- pass: 9223372036854775837  fail: 10                   time: 5ms
SOME TESTS FAILED (9223372036854779929/9223372036854779939)
```
![image](https://user-images.githubusercontent.com/6484464/61653365-2fb15480-accb-11e9-9c6b-a0e403c73be1.png)

